### PR TITLE
Assigning loot ownership + small fixes (#181)

### DIFF
--- a/Intersect (Core)/Config/LootOptions.cs
+++ b/Intersect (Core)/Config/LootOptions.cs
@@ -1,0 +1,24 @@
+﻿namespace Intersect.Config
+{
+    /// <summary>
+    /// Contains configurable options pertaining to the way loot (item) drops are handled by the engine.
+    /// </summary>
+    public class LootOptions
+    {
+
+        /// <summary>
+        /// Defines how long (in ms) loot will be available for picking up on the map.
+        /// </summary>
+        public int ItemDespawnTime = 15000;
+
+        /// <summary>
+        /// Defines how long (in ms) an item drop will be ''owned'' by a player and their party.
+        /// </summary>
+        public int ItemOwnershipTime = 5000;
+
+        /// <summary>
+        /// Defines whether players can see items they do not ''own'' on the map.
+        /// </summary>
+        public bool ShowUnownedItems = false;
+    }
+}

--- a/Intersect (Core)/Config/MapOptions.cs
+++ b/Intersect (Core)/Config/MapOptions.cs
@@ -12,9 +12,7 @@ namespace Intersect.Config
 
         public int Height = 26;
 
-        public int ItemDespawnTime = 15000;
-
-        public int ItemSpawnTime = 15000;
+        public int ItemAttributeRespawnTime = 15000;
 
         public int TileHeight = 32;
 

--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -54,6 +54,8 @@ namespace Intersect
 
         [JsonProperty("Security")] public SecurityOptions SecurityOpts = new SecurityOptions();
 
+        [JsonProperty("Loot")] public LootOptions LootOpts = new LootOptions();
+
         public SmtpSettings SmtpSettings = new SmtpSettings();
 
         [NotNull]
@@ -115,10 +117,6 @@ namespace Intersect
 
         public static int GameBorderStyle => Instance.MapOpts.GameBorderStyle;
 
-        public static int ItemRepawnTime => Instance.MapOpts.ItemSpawnTime;
-
-        public static int ItemDespawnTime => Instance.MapOpts.ItemDespawnTime;
-
         public static bool ZDimensionVisible => Instance.MapOpts.ZDimensionVisible;
 
         public static int MapWidth => Instance?.MapOpts?.Width ?? 32;
@@ -134,6 +132,8 @@ namespace Intersect
         public static int MaxChatLength => Instance.ChatOpts.MaxChatLength;
 
         public static int MinChatInterval => Instance.ChatOpts.MinIntervalBetweenChats;
+
+        public static LootOptions Loot => Instance.LootOpts;
 
         public static bool UPnP => Instance._upnp;
 

--- a/Intersect (Core)/Intersect (Core).csproj
+++ b/Intersect (Core)/Intersect (Core).csproj
@@ -191,6 +191,7 @@
     <Compile Include="Configuration\IConfiguration.cs" />
     <Compile Include="Configuration\ConfigurationHelper.cs" />
     <Compile Include="Config\ChatOptions.cs" />
+    <Compile Include="Config\LootOptions.cs" />
     <Compile Include="Config\PacketOptions.cs" />
     <Compile Include="Config\PartyOptions.cs" />
     <Compile Include="Config\SecurityOptions.cs" />

--- a/Intersect.Client/Entities/Entity.cs
+++ b/Intersect.Client/Entities/Entity.cs
@@ -846,7 +846,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1217,7 +1217,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1309,7 +1309,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }
@@ -1430,7 +1430,7 @@ namespace Intersect.Client.Entities
                 //If unit is stealthed, don't render unless the entity is the player.
                 if (Status[n].Type == StatusTypes.Stealth)
                 {
-                    if (this != Globals.Me && !Globals.Me.IsInMyParty(this))
+                    if (this != Globals.Me && !(this is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         return;
                     }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 
 using Intersect.Client.Core;
@@ -114,21 +115,9 @@ namespace Intersect.Client.Entities
             return Party.Count > 0;
         }
 
-        public bool IsInMyParty(Entity entity)
-        {
-            if (EntityTypes.Player == entity.GetEntityType())
-            {
-                foreach (var member in Party)
-                {
-                    if (member.Id == entity.Id)
-                    {
-                        return true;
-                    }
-                }
-            }
+        public bool IsInMyParty(Player player) => IsInMyParty(player.Id);
 
-            return false;
-        }
+        public bool IsInMyParty(Guid id) => Party.Any(member => member.Id == id);
 
         public bool IsBusy()
         {
@@ -888,7 +877,7 @@ namespace Intersect.Client.Entities
                     if (en.Value.GetEntityType() == EntityTypes.GlobalEntity ||
                         en.Value.GetEntityType() == EntityTypes.Player)
                     {
-                        if (en.Value != Globals.Me && !Globals.Me.IsInMyParty(en.Value))
+                        if (en.Value != Globals.Me && !(en.Value is Player player && Globals.Me.IsInMyParty(player)))
                         {
                             if (GetDistanceTo(en.Value) < GetDistanceTo(closestEntity))
                             {
@@ -1137,7 +1126,7 @@ namespace Intersect.Client.Entities
                                 if (en.Value.CurrentMap == mapId &&
                                     en.Value.X == x &&
                                     en.Value.Y == y &&
-                                    (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                                    (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                                 {
                                     if (en.Value.GetType() != typeof(Projectile) &&
                                         en.Value.GetType() != typeof(Resource))
@@ -1202,7 +1191,7 @@ namespace Intersect.Client.Entities
                                         en.Value.X == x &&
                                         en.Value.Y == y &&
                                         !((Event) en.Value).DisablePreview &&
-                                        (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                                        (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                                     {
                                         if (TargetBox != null)
                                         {
@@ -1267,6 +1256,13 @@ namespace Intersect.Client.Entities
             {
                 if (item.Value.X == X && item.Value.Y == Y)
                 {
+                    // Are we allowed to see and pick this item up?
+                    if (!item.Value.VisibleToAll && item.Value.Owner != Globals.Me.Id && !Globals.Me.IsInMyParty(item.Value.Owner))
+                    {
+                        // This item does not apply to us!
+                        return false;
+                    }
+
                     PacketSender.SendPickupItem(item.Key);
 
                     return true;
@@ -1775,7 +1771,7 @@ namespace Intersect.Client.Entities
                     continue;
                 }
 
-                if (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value))
+                if (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player))
                 {
                     if (en.Value.GetType() != typeof(Projectile) && en.Value.GetType() != typeof(Resource))
                     {
@@ -1803,7 +1799,7 @@ namespace Intersect.Client.Entities
 
                     if (en.Value.CurrentMap == eventMap.Id &&
                         !((Event) en.Value).DisablePreview &&
-                        (!en.Value.IsStealthed() || Globals.Me.IsInMyParty(en.Value)))
+                        (!en.Value.IsStealthed() || en.Value is Player player && Globals.Me.IsInMyParty(player)))
                     {
                         if (TargetType == 1 && TargetIndex == en.Value.Id)
                         {

--- a/Intersect.Client/Items/MapItem.cs
+++ b/Intersect.Client/Items/MapItem.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+
 
 namespace Intersect.Client.Items
 {
@@ -9,6 +11,10 @@ namespace Intersect.Client.Items
         public int X;
 
         public int Y;
+
+        public Guid Owner;
+
+        public bool VisibleToAll;
 
         public MapItemInstance() : base()
         {

--- a/Intersect.Client/Maps/MapInstance.cs
+++ b/Intersect.Client/Maps/MapInstance.cs
@@ -651,6 +651,13 @@ namespace Intersect.Client.Maps
             //Draw Map Items
             foreach (var item in MapItems)
             {
+                // Are we allowed to see and pick this item up?
+                if (!item.Value.VisibleToAll && item.Value.Owner != Globals.Me.Id && !Globals.Me.IsInMyParty(item.Value.Owner))
+                {
+                    // This item does not apply to us!
+                    continue;
+                }
+
                 var itemBase = ItemBase.Get(item.Value.ItemId);
                 if (itemBase != null)
                 {

--- a/Intersect.Server/Entities/Entity.cs
+++ b/Intersect.Server/Entities/Entity.cs
@@ -1776,21 +1776,14 @@ namespace Intersect.Server.Entities
                         dmgMap.TryGetValue(this, out var damage);
                         dmgMap[this] = damage + baseDamage;
 
-                        long dmg = baseDamage;
-                        var newTarget = this;
                         if (enemyNpc.Base.FocusHighestDamageDealer)
                         {
-                            foreach (var pair in dmgMap)
-                            {
-                                if (pair.Value > dmg)
-                                {
-                                    newTarget = pair.Key;
-                                    dmg = pair.Value;
-                                }
-                            }
+                            enemyNpc.AssignTarget(enemyNpc.DamageMapHighest);
                         }
-
-                        enemyNpc.AssignTarget(newTarget);
+                        else
+                        {
+                            enemyNpc.AssignTarget(this);
+                        }
                     }
 
                     enemy.NotifySwarm(this);
@@ -1827,21 +1820,9 @@ namespace Intersect.Server.Entities
                     //No Matter what, if we attack the entitiy, make them chase us
                     if (enemy is Npc enemyNpc)
                     {
-                        var dmgMap = enemyNpc.DamageMap;
-                        var target = this;
-                        long dmg = 0;
-                        foreach (var pair in dmgMap)
-                        {
-                            if (pair.Value > dmg)
-                            {
-                                target = pair.Key;
-                                dmg = pair.Value;
-                            }
-                        }
-
                         if (enemyNpc.Base.FocusHighestDamageDealer)
                         {
-                            enemyNpc.AssignTarget(target);
+                            enemyNpc.AssignTarget(enemyNpc.DamageMapHighest);
                         }
                         else
                         {
@@ -2438,9 +2419,29 @@ namespace Intersect.Server.Entities
                         continue;
                     }
 
-                    var map = MapInstance.Get(MapId);
-                    map?.SpawnItem(X, Y, item, item.Quantity);
+                    // Decide if we want to have a loot ownership timer or not.
+                    Guid lootOwner = Guid.Empty;
+                    if (this is Npc thisNpc)
+                    {
+                        // Check if we have someone that tagged this NPC.
+                        var taggedBy = thisNpc.DamageMapHighest;
+                        if (taggedBy != null && taggedBy is Player)
+                        {
+                            // Spawn with ownership!
+                            lootOwner = taggedBy.Id;
+                        }
+                    } 
+                    else
+                    {
+                        // There's no tracking of who damaged what player as of now, so going by last hit.. Or set ownership to the player themselves.
+                        lootOwner = playerKiller?.Id ?? Id;
+                    }
 
+                    // Spawn the actual item!
+                    var map = MapInstance.Get(MapId);
+                    map?.SpawnItem(X, Y, item, item.Quantity, lootOwner);
+
+                    // Remove the item from inventory if a player.
                     var player = this as Player;
                     player?.TakeItemsBySlot(n, item.Quantity);
                 }

--- a/Intersect.Server/Entities/Npc.cs
+++ b/Intersect.Server/Entities/Npc.cs
@@ -29,8 +29,29 @@ namespace Intersect.Server.Entities
         //Spell casting
         public long CastFreq;
 
-        //Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
+        /// <summary>
+        /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
+        /// </summary>
         public ConcurrentDictionary<Entity, long> DamageMap = new ConcurrentDictionary<Entity, long>();
+
+        /// <summary>
+        /// Returns the entity that ranks the highest on this NPC's damage map.
+        /// </summary>
+        public Entity DamageMapHighest { 
+            get {
+                long damage = 0;
+                Entity top = null;
+                foreach (var pair in DamageMap)
+                {
+                    if (pair.Value > damage)
+                    {
+                        top = pair.Key;
+                        damage = pair.Value;
+                    }
+                }
+                return top;
+            } 
+        }
 
         public bool Despawnable;
 

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1510,7 +1510,7 @@ namespace Intersect.Server.Entities
                 return;
             }
 
-            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1);
+            map.SpawnItem(X, Y, Items[slotIndex], itemBase.IsStackable ? amount : 1, Id);
 
             slot.Quantity = Math.Max(0, slot.Quantity - amount);
 
@@ -3427,7 +3427,7 @@ namespace Intersect.Server.Entities
 
                 if (!TryGiveItem(new Item(offer)))
                 {
-                    MapInstance.Get(MapId)?.SpawnItem(X, Y, offer, offer.Quantity);
+                    MapInstance.Get(MapId)?.SpawnItem(X, Y, offer, offer.Quantity, Id);
                     PacketSender.SendChatMsg(this, Strings.Trading.itemsdropped, CustomColors.Alerts.Error);
                 }
 

--- a/Intersect.Server/Entities/Resource.cs
+++ b/Intersect.Server/Entities/Resource.cs
@@ -161,7 +161,7 @@ namespace Intersect.Server.Entities
                     if (ItemBase.Get(item.ItemId) != null)
                     {
                         MapInstance.Get(selectedTile.GetMapId())
-                            .SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity);
+                            .SpawnItem(selectedTile.GetX(), selectedTile.GetY(), item, item.Quantity, killer.Id);
                     }
                 }
             }

--- a/Intersect.Server/Localization/Strings.cs
+++ b/Intersect.Server/Localization/Strings.cs
@@ -776,6 +776,14 @@ namespace Intersect.Server.Localization
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public readonly LocalizedString stunned = @"You cannot use this item whilst stunned.";
 
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString NotYours = @"This item does not belong to you!";
+
+            // TODO: Generalize this shit. It's everywhere!
+            [NotNull, JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public readonly LocalizedString InventoryNoSpace =
+                @"There is no space left in your inventory for that item!";
+
         }
 
         public sealed class MappingNamespace : LocaleNamespace

--- a/Intersect.Server/Maps/MapItemInstance.cs
+++ b/Intersect.Server/Maps/MapItemInstance.cs
@@ -17,6 +17,13 @@ namespace Intersect.Server.Maps
 
         [JsonIgnore] public long DespawnTime;
 
+        public Guid Owner;
+
+        [JsonIgnore] public long OwnershipTime;
+
+        // We need this mostly for the client-side.. They can't keep track of our timer after all!
+        public bool VisibleToAll = true;
+
         public int X = 0;
 
         public int Y = 0;


### PR DESCRIPTION
* Added loot ownership

* Map items can be spawned with an owner, and only be picked up by the owner and their party. Anyone can still see it, however.
* The time that loot is exclusive to the owner and their party is configurable through the server's config.json under Map Options.
* NPC Drops are owned by the player (and their party) that dealt the most damage to them. (Unless killed by an NPC or something else, then there is no owner)
* Player drops on death are owned by whoever dealt the killing blow and their party.
* Items dropped from your inventory to the map are owned by you and your party until the timer expires.

* Made the packet handler for PickupItempacket slightly less a hassle to read by shortening some checks.

* Removed useless reference and fixed an issue

Removed a useless reference to System from a random test I forgot to remove.

Fixed an oversight in the way the owner was determined by the amount of damage done to an NPC.. It should now no longer always use the last player in the list, but the one with the most damage.

* General code cleanup

Cleaned up my loot tagging attempt in Entity.Die, as well as some general cleaning up of repeated code using Npc.DamageBase.

* Fixed an NPC behaviour check I skipped over last cleanup

* Add an option to hide loot for players until the ownership claim drops.

Added a configurable option to the server configuration (ShowUnownedItems) that can either show or hide loot for players that are not the owner and not in the owner's party until the claim on that item is dropped by the server.

Disabled attempts at picking up invisible items as well.

* Fix a potential error here, in case the item gets deleted before it should become visible.

* Small death rule change if player dies from anything but another player.

Changed the way item ownership is handled upon player death to set ownership to them (and their party) should a player die from anything that is not another player.

* Moved the two new options to their own Options section.

Would prefer to move these as well:

ItemDespawnTime
ItemSpawnTime

But this would definitely break existing configs.

* Added the error a player gets when attempting to pick up an item that does not belong to them localizable.

* Requested changes for pr #181

- Added Xml summaries to LootOptions.cs
- Made LootOptions a child of Options rather than adding more top level options.
- Changed both Player.IsInMyParty checks to instead be simple Linq queries and enforces a player to be passed on.
- Fixed some places that would throw any entity into the Player.IsInMyParty method.
- Changed the new translation string to be Mixed Case and added the NotNull property.
- Changed some MapItem update logic on MapInstance to not refer to each item by id every time, but a simpler re-usable variable.
- Changed more Guid comparisons
- Added a message to picking up items on the server side if the user's inventory is full.
- Added some Todo's to MapOptions for items that could be moved or renamed for clarity.

* Updated the alert messages to utilize CustomColors

* JC Said I could do this. :coy:

Removes ItemDespawnTime from the MapOptions class and places it in the LootOptions class where it beloongs.

Renames ItemSpawnTime in MapOptions to ItemAttributeRespawnTime which is far more descriptive of what it actually does.

Removes these two options from the top level Options class, like why is almost everything there anyway if we have categories?

* Items forcibly returned by trading and items dropped by resources are now tagged with an owner.

* Fix a small bug unrelated to my code related to regenerating NPC vitals, the code would never actually execute for NPCs.

* Resolve some review problems.