### PR TITLE
Make the maximum party size user configurable (#221)

### DIFF
--- a/Intersect (Core)/Config/Options.cs
+++ b/Intersect (Core)/Config/Options.cs
@@ -83,12 +83,6 @@ namespace Intersect
 
         public static int RequestTimeout => Instance.PlayerOpts.RequestTimeout;
 
-        public static int PartyInviteRange => Instance.PartyOpts.InviteRange;
-
-        public static int PartySharedXpRange => Instance.PartyOpts.SharedXpRange;
-
-        public static int PartyStartCommonEventRange => Instance.PartyOpts.NpcDeathCommonEventStartRange;
-
         public static int TradeRange => Instance.PlayerOpts.TradeRange;
 
         public static int WeaponIndex => Instance.EquipmentOpts.WeaponSlot;
@@ -134,6 +128,8 @@ namespace Intersect
         public static int MinChatInterval => Instance.ChatOpts.MinIntervalBetweenChats;
 
         public static LootOptions Loot => Instance.LootOpts;
+
+        public static PartyOptions Party => Instance.PartyOpts;
 
         public static bool UPnP => Instance._upnp;
 

--- a/Intersect (Core)/Config/PartyOptions.cs
+++ b/Intersect (Core)/Config/PartyOptions.cs
@@ -8,6 +8,11 @@ namespace Intersect.Config
 {
     public class PartyOptions
     {
+        
+        /// <summary>
+        /// Defines the maximum amount of members a party can have.
+        /// </summary>
+        public int MaximumMembers = 4;
 
         public int InviteRange = 40;
 

--- a/Intersect.Client/Interface/Game/PartyWindow.cs
+++ b/Intersect.Client/Interface/Game/PartyWindow.cs
@@ -72,7 +72,7 @@ namespace Intersect.Client.Interface.Game
             mHpBarContainer.Clear();
             mHpBar.Clear();
 
-            for (var i = 0; i < 4; i++)
+            for (var i = 0; i < Options.Party.MaximumMembers; i++)
             {
                 //Labels
                 mLblnames.Add(new Label(mPartyWindow, "MemberName" + i));

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -861,7 +861,7 @@ namespace Intersect.Server.Entities
                     // If in party, split the exp.
                     if (Party != null && Party.Count > 0)
                     {
-                        var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.PartySharedXpRange));
+                        var partyMembersInXpRange = Party.Where(partyMember => partyMember.InRangeOf(this, Options.Party.SharedXpRange));
                         var partyExperience = descriptor.Experience / partyMembersInXpRange.Count();
                         foreach (var partyMember in partyMembersInXpRange) {
                             partyMember.GiveExperience(partyExperience);
@@ -871,7 +871,7 @@ namespace Intersect.Server.Entities
                         if (partyEvent != null)
                         {
                             foreach (var partyMember in Party) {
-                                if (partyMember.InRangeOf(this, Options.PartyStartCommonEventRange) && !(partyMember == this && playerEvent != null)) {
+                                if (partyMember.InRangeOf(this, Options.Party.NpcDeathCommonEventStartRange) && !(partyMember == this && playerEvent != null)) {
                                     partyMember.StartCommonEvent(partyEvent);
                                 }
                             }
@@ -3793,7 +3793,7 @@ namespace Intersect.Server.Entities
                 }
             }
 
-            if (Party.Count < 10)
+            if (Party.Count < Options.Party.MaximumMembers)
             {
                 target.LeaveParty();
                 Party.Add(target);

--- a/Intersect.Server/Networking/PacketHandler.cs
+++ b/Intersect.Server/Networking/PacketHandler.cs
@@ -1477,7 +1477,7 @@ namespace Intersect.Server.Networking
 
             var target = Player.FindOnline(packet.TargetId);
 
-            if (target != null && target.Id != player.Id && player.InRangeOf(target, Options.PartyInviteRange))
+            if (target != null && target.Id != player.Id && player.InRangeOf(target, Options.Party.InviteRange))
             {
                 target.InviteToParty(player);
 


### PR DESCRIPTION
- Fixes a max party size discrepancy where it was accidentally set to 10, but was still 4 in other areas.
- Added a Party option to allow the maximum party size to be set through the server config file.
- Removed some Top Level party config options, they should really be referenced through the Party section.